### PR TITLE
POST /client/servers_with_addresses

### DIFF
--- a/client/clientauth.js
+++ b/client/clientauth.js
@@ -138,15 +138,14 @@ module.exports = ( fastify, opts, done ) => {
 		    querystring: {
 		      id: { type: "string" }, // id of the player trying to auth
 		      playerToken: { type: "string" }, // not implemented yet: the authing player's account token
-		      server: { type: "string" },
-		      password: { type: "string" } // the password the player is using to connect to the server
+		      server: { type: "string" }
 		    }
 		  }
 		},
 		async ( request, reply ) => {
 		  let server = GetGameServers()[ request.query.server ]
 
-		  if ( !server || ( server.hasPassword && request.query.password != server.password ) )
+		  if ( !server || server.hasPassword )
 		    return { success: false }
 
 		  let account = await accounts.AsyncGetPlayerByID( request.query.id )
@@ -167,8 +166,7 @@ module.exports = ( fastify, opts, done ) => {
 		  return {
 		    success: true,
 
-		    ip: server.ip,
-		    port: server.port
+		    ip: server.ip
 		  }
 	})
 	

--- a/client/clientauth.js
+++ b/client/clientauth.js
@@ -128,49 +128,6 @@ module.exports = ( fastify, opts, done ) => {
 		}
 	})
 	
-	
-	// POST /client/get_server_address
-	// sends the address of the server to a client
-	// requires client to be authenticated with the master server for added security
-	fastify.post( '/client/get_server_address', 
-		{
-		  schema: {
-		    querystring: {
-		      id: { type: "string" }, // id of the player trying to auth
-		      playerToken: { type: "string" }, // not implemented yet: the authing player's account token
-		      server: { type: "string" }
-		    }
-		  }
-		},
-		async ( request, reply ) => {
-		  let server = GetGameServers()[ request.query.server ]
-
-		  if ( !server || server.hasPassword )
-		    return { success: false }
-
-		  let account = await accounts.AsyncGetPlayerByID( request.query.id )
-		  if ( !account )
-		    return { success: false }
-
-		  if ( shouldRequireSessionToken )
-		  {
-		    // check token
-		    if ( request.query.playerToken != account.currentAuthToken )
-		      return { success: false }
-
-		    // check expired token
-		    if ( account.currentAuthTokenExpirationTime < Date.now() )
-		      return { success: false }
-		  }
-
-		  return {
-		    success: true,
-
-		    ip: server.ip
-		  }
-	})
-	
-	
 	// POST /client/auth_with_self
 	// attempts to authenticate a client with their own server, before the server is created
 	// note: atm, this just sends pdata to clients and doesn't do any kind of auth stuff, potentially rewrite later

--- a/client/serverlist.js
+++ b/client/serverlist.js
@@ -1,5 +1,8 @@
 const path = require( "path" )
 const { GameServer, GetGameServers, RemoveGameServer } = require( path.join( __dirname, "../shared/gameserver.js" ) )
+const accounts = require( path.join( __dirname, "../shared/accounts.js" ) ) 
+
+let shouldRequireSessionToken = process.env.REQUIRE_SESSION_TOKEN = true
 
 module.exports = ( fastify, opts, done ) => {
 	// exported routes
@@ -28,6 +31,70 @@ module.exports = ( fastify, opts, done ) => {
 			// create a copy of the gameserver obj for clients so we can hide sensitive info
 			let copy = new GameServer( servers[ i ] )
 			delete copy.ip
+			delete copy.port
+			delete copy.authPort
+			delete copy.password
+			
+			displayServerArray.push( copy )
+		}
+		
+		// delete servers that we've marked for deletion
+		for ( let server of expiredServers )
+			RemoveGameServer( server )
+		
+		return displayServerArray
+	})
+	
+	// GET /client/servers_with_addresses
+	// returns a list of available servers with their IP addresses if they are not password-protected
+	fastify.get( '/client/servers_with_addresses', 
+		{
+		  schema: {
+		    querystring: {
+		      id: { type: "string" }, // id of the player trying to auth
+		      playerToken: { type: "string" }, // not implemented yet: the authing player's account token
+		    }
+		  }
+		},
+		async ( request, response ) => {
+		let displayServerArray = []
+		let expiredServers = [] // might be better to move this to another function at some point, but easiest to do here atm
+		
+		let account = await accounts.AsyncGetPlayerByID( request.query.id )
+		if ( !account )
+		  return []
+
+		if ( shouldRequireSessionToken )
+		{
+		  // check token
+		  if ( request.query.playerToken != account.currentAuthToken )
+		    return []
+
+		  // check expired token
+		  if ( account.currentAuthTokenExpirationTime < Date.now() )
+		    return []
+		}
+		
+		let servers = Object.values( GetGameServers() )
+				
+		for ( let i = 0; i < servers.length; i++ )
+		{			
+			// prune servers if they've had 30 seconds since last heartbeat
+			if ( Date.now() - servers[ i ].lastHeartbeat > 30000 )
+			{
+				expiredServers.push( servers[ i ] )
+				continue
+			}
+			
+			// don't show non-private_match servers on lobby since they'll pollute server list
+			if ( servers[ i ].map == "mp_lobby" && servers[ i ].playlist != "private_match" )
+				continue
+			
+			// create a copy of the gameserver obj for clients so we can hide sensitive info
+			let copy = new GameServer( servers[ i ] )
+			if(copy.hasPassword) {
+				delete copy.ip
+			}
 			delete copy.port
 			delete copy.authPort
 			delete copy.password


### PR DESCRIPTION
This PR solves the problems with #4 by allowing authed clients to get a server list with the IPs of any open servers included.

> Adds the ability for servers' addresses to be sent to the client independent of authenticating with them so that the client can check the ping of the server.
> 
> Can be used to get server ping without adding much stress to game servers.