### PR TITLE
Add /wiki endpoint that redirects to wiki URL

### DIFF
--- a/client/redirect.js
+++ b/client/redirect.js
@@ -15,5 +15,12 @@ module.exports = ( fastify, opts, done ) => {
         reply.redirect( "https://discord.gg/GYVRKC9pJh" )
     })
 
+    // GET /wiki
+    // redirect anyone going to northstar.tf/wiki to the wiki
+    fastify.get( '/wiki',
+    async ( request, reply ) => {
+        reply.redirect( "https://r2northstar.gitbook.io/" )
+    })
+
     done()
 }


### PR DESCRIPTION
Similar to the `/discord` endpoint, `/wiki` redirects to whatever is considered the official Northstar wiki. Currently this points to `https://r2northstar.gitbook.io/`.
Should we however decide to switch away from GitBook in the future, we can just update the redirect URL for this endpoint without having to update references to wiki everywhere

Alternatively a subdomain of `northstar.tf`, like `wiki.northstar.tf` could be used to achieve the same thing.