### PR TITLE
Add optional env variable to get client IP from a custom header

### DIFF
--- a/account/accountpersistence.js
+++ b/account/accountpersistence.js
@@ -19,6 +19,13 @@ module.exports = ( fastify, opts, done ) => {
 		},
 	},
 	async ( request, response ) => {
+		
+		let clientIp = request.ip
+	
+		// pull the client ip address from a custom header if one is specified
+		if (process.env.CLIENT_IP_HEADER && request.headers[process.env.CLIENT_IP_HEADER])
+			clientIp = request.headers[process.env.CLIENT_IP_HEADER]
+		
 		// check if account exists 
 		let account = await accounts.AsyncGetPlayerByID( request.query.id )
 		if ( !account )
@@ -29,7 +36,7 @@ module.exports = ( fastify, opts, done ) => {
 		{
 			let server = GetGameServers()[ request.query.serverId ]
 			// dont update if the server doesnt exist, or the server isnt the one sending the heartbeat
-			if ( !server || request.ip != server.ip || account.currentServerId != request.query.serverId )
+			if ( !server || clientIp != server.ip || account.currentServerId != request.query.serverId )
 				return null
 		}
 		

--- a/dev.env
+++ b/dev.env
@@ -5,6 +5,10 @@ LISTEN_IP=0.0.0.0
 LISTEN_PORT=8080
 REQUIRE_SESSION_TOKEN=
 
+# if the proxy provides a custom header to get the client's ip address
+# (example: cloudflare uses CF-Connecting-IP)
+CLIENT_IP_HEADER=
+
 # not used for dev
 SSL_KEY_PATH=
 SSL_CERT_PATH=

--- a/server/gameserver.js
+++ b/server/gameserver.js
@@ -13,6 +13,12 @@ async function SharedTryAddServer( request )
 	// check server's verify endpoint on their auth server, make sure it's fine
 	// in the future we could probably check the server's connect port too, with a c2s_connect packet or smth, but atm this is good enough
 
+	let clientIp = request.ip
+	
+	// pull the client ip address from a custom header if one is specified
+	if (process.env.CLIENT_IP_HEADER && request.headers[process.env.CLIENT_IP_HEADER])
+		clientIp = request.headers[process.env.CLIENT_IP_HEADER]
+	
 	let hasValidModInfo = true
 	let modInfo
 	
@@ -28,7 +34,7 @@ async function SharedTryAddServer( request )
 
 	let authServerResponse = await asyncHttp.request( {
 		method: "GET",
-		host: request.ip,
+		host: clientIp,
 		port: request.query.authPort,
 		path: "/verify"
 	})
@@ -72,7 +78,7 @@ async function SharedTryAddServer( request )
 
 	let name = filter.clean( request.query.name )
 	let description = request.query.description == "" ? "" : filter.clean( request.query.description )
-	let newServer = new GameServer( name, description, playerCount, request.query.maxPlayers, request.query.map, request.query.playlist, request.ip, request.query.port, request.query.authPort, request.query.password, modInfo )
+	let newServer = new GameServer( name, description, playerCount, request.query.maxPlayers, request.query.map, request.query.playlist, clientIp, request.query.port, request.query.authPort, request.query.password, modInfo )
 	AddGameServer( newServer )
 
 	return {
@@ -120,9 +126,16 @@ module.exports = ( fastify, opts, done ) => {
 		}
 	},
 	async ( request, reply ) => {
+		
+		let clientIp = request.ip
+	
+		// pull the client ip address from a custom header if one is specified
+		if (process.env.CLIENT_IP_HEADER && request.headers[process.env.CLIENT_IP_HEADER])
+			clientIp = request.headers[process.env.CLIENT_IP_HEADER]
+		
 		let server = GetGameServers()[ request.query.id ]
 		// dont update if the server doesnt exist, or the server isnt the one sending the heartbeat
-		if ( !server || request.ip != server.ip || !request.query.id )// remove !request.playerCount as if playercount==0 it will trigger skip heartbeat update
+		if ( !server || clientIp != server.ip || !request.query.id )// remove !request.playerCount as if playercount==0 it will trigger skip heartbeat update
 		{
 			return null
 		}
@@ -139,6 +152,13 @@ module.exports = ( fastify, opts, done ) => {
 	// updates values shown on the server list, such as map, playlist, or player count
 	// no schema for this one, since it's fully dynamic and fastify doesnt do optional params
 	fastify.post( '/server/update_values', async ( request, reply ) => {
+		
+		let clientIp = request.ip
+	
+		// pull the client ip address from a custom header if one is specified
+		if (process.env.CLIENT_IP_HEADER && request.headers[process.env.CLIENT_IP_HEADER])
+			clientIp = request.headers[process.env.CLIENT_IP_HEADER]
+		
 		if ( !( "id" in request.query ) )
 			return null
 		
@@ -149,7 +169,7 @@ module.exports = ( fastify, opts, done ) => {
 		{
 			return SharedTryAddServer( request )
 		}
-		else if ( request.ip != server.ip ) // dont update if the server isnt the one sending the heartbeat
+		else if ( clientIp != server.ip ) // dont update if the server isnt the one sending the heartbeat
 			return null
 
 		// update heartbeat
@@ -186,7 +206,7 @@ module.exports = ( fastify, opts, done ) => {
 	async ( request, reply ) => {
 		let server = GetGameServers()[ request.query.id ]
 		// dont remove if the server doesnt exist, or the server isnt the one sending the heartbeat
-		if ( !server || request.ip != server.ip )
+		if ( !server || clientIp != server.ip )
 			return null
 		
 		RemoveGameServer( server )


### PR DESCRIPTION
Some proxy services (like Cloudflare) set a custom header on proxied requests that can be used to extract the original IP address of the connecting client.

This PR adds the ability to use such a header through an optional env variable.

https://developers.cloudflare.com/fundamentals/get-started/http-request-headers