### PR TITLE
Add redirects for invites

### DIFF
--- a/client/invites.js
+++ b/client/invites.js
@@ -1,0 +1,18 @@
+const { getRatelimit } = require( "../shared/ratelimit.js" )
+
+module.exports = ( fastify, opts, done ) =>
+{
+	// exported routes
+
+	// GET /
+	// redirect anyone going to northstar.tf/github in a browser to the github
+	fastify.get( "/invite/server/*",
+		{
+			config: { rateLimit: getRatelimit( "REQ_PER_MINUTE__REDIRECT" ) }, // ratelimit
+		},
+		async ( request, reply ) =>
+		{
+			reply.redirect( "northstar://server@" + request.url.substring(15) )
+		} )
+	done()
+}


### PR DESCRIPTION
Adds some masterserver code for automatically redirecting invites to the `northstar://` protocol. Useful for generating clickable links