### PR TITLE
Encode usernames so that they are valid URI strings

### DIFF
--- a/client/clientauth.js
+++ b/client/clientauth.js
@@ -160,7 +160,7 @@ module.exports = ( fastify, opts, done ) =>
 					method: "POST",
 					host: server.ip,
 					port: server.authPort,
-					path: `/authenticate_incoming_player?id=${request.query.id}&authToken=${authToken}&serverAuthToken=${server.serverAuthToken}&username=${account.username}`
+					path: `/authenticate_incoming_player?id=${request.query.id}&authToken=${authToken}&serverAuthToken=${server.serverAuthToken}&username=${encodeURI( account.username )}`
 				}, pdata )
 			}
 			catch


### PR DESCRIPTION
Some users were failing auth due to their name not being a valid URI string, namely "Gromit      " (6 spaces) ended up being shortened to "Gromit" and therefore was failing auth

This could use some testing, idk how to test this particular case properly tbh