### PR TITLE
Reject non-string values in server/update_values

### DIFF
--- a/server/gameserver.js
+++ b/server/gameserver.js
@@ -248,7 +248,7 @@ module.exports = ( fastify, opts, done ) =>
 
 			for ( let key of Object.keys( request.query ) )
 			{
-				if ( key == "id" || key == "port" || key == "authport" || !( key in server ) || request.query[ key ].length >= 512 )
+				if ( key == "id" || key == "port" || key == "authport" || !( key in server ) || request.query[ key ].length >= 512 || typeof request.query[ key ] != "string" )
 					continue
 
 				if ( key == "playerCount" || key == "maxPlayers" )


### PR DESCRIPTION
Fixes an issue where multiple of one query param would make a server disappear from the server list on clients as that would become an array