### PR TITLE
Cast environment variable to number

### DIFF
--- a/shared/origin.js
+++ b/shared/origin.js
@@ -63,7 +63,7 @@ async function authWithOrigin()
 	}
 }
 
-if( process.env.ORIGIN_ENABLE )
+if( Number( process.env.ORIGIN_ENABLE ) )
 {
 	console.log( "Attempting to auth with Origin" )
 	if( process.env.ORIGIN_PERSIST_SID && fs.existsSync( "./sid.cookie" ) )


### PR DESCRIPTION
It's a string otherwise so setting `ORIGIN_ENABLE=0` in `.env` results in `"0"` which is still `true`.