### PR TITLE
Add region field to server entry

### DIFF
--- a/server/gameserver.js
+++ b/server/gameserver.js
@@ -183,7 +183,7 @@ async function TryReviveServer( request )
 
 	let name = filter.clean( request.query.name )
 	let description = request.query.description == "" ? "" : filter.clean( request.query.description )
-	let region = await getGeoIp( request )
+	let region = ghost.region // Given that we don't allow reviving ghost from different IP it also shouldn't be able to switch region
 	let newServer = new GameServer( name, description, playerCount, request.query.maxPlayers, request.query.map, request.query.playlist, request.ip, ghost.port, ghost.authPort, request.query.password, modInfo, region )
 	newServer.id = ghost.id
 	AddGameServer( newServer )

--- a/server/gameserver.js
+++ b/server/gameserver.js
@@ -100,12 +100,14 @@ async function getGeoIp( request )
 		return ""
 	}
 
-	let json_response = JSON.parse(geoIpResonse.toString())
+	let json_response = JSON.parse( geoIpResonse.toString() )
 
-	if ( json_response.status === 'success' ) {
+	if ( json_response.status === "success" )
+	{
 		return json_response.continent
 	}
-	else {
+	else
+	{
 		// geoip request was not succesfull, return empty string
 		return ""
 	}

--- a/shared/gameserver.js
+++ b/shared/gameserver.js
@@ -19,7 +19,9 @@ class GameServer
 	// object modInfo
 	// object pdiff
 
-	constructor( nameOrServer, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password = "", modInfo = { Mods: [] } )
+	// string region
+
+	constructor( nameOrServer, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password = "", modInfo = { Mods: [] }, region )
 	{
 		if ( nameOrServer instanceof( GameServer ) ) // copy constructor
 		{
@@ -27,7 +29,7 @@ class GameServer
 
 			this.id = nameOrServer.id
 			this.serverAuthToken = nameOrServer.serverAuthToken
-			this.updateValues( nameOrServer.name, nameOrServer.description, nameOrServer.playerCount, nameOrServer.maxPlayers, nameOrServer.map, nameOrServer.playlist, nameOrServer.ip, nameOrServer.port, nameOrServer.authPort, nameOrServer.password, nameOrServer.modInfo, nameOrServer.pdiffs )
+			this.updateValues( nameOrServer.name, nameOrServer.description, nameOrServer.playerCount, nameOrServer.maxPlayers, nameOrServer.map, nameOrServer.playlist, nameOrServer.ip, nameOrServer.port, nameOrServer.authPort, nameOrServer.password, nameOrServer.modInfo, nameOrServer.region )
 		}
 		else // normal constructor
 		{
@@ -35,11 +37,11 @@ class GameServer
 
 			this.id = crypto.randomBytes( 16 ).toString( "hex" )
 			this.serverAuthToken = crypto.randomBytes( 16 ).toString( "hex" )
-			this.updateValues( nameOrServer, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password, modInfo )
+			this.updateValues( nameOrServer, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password, modInfo, region )
 		}
 	}
 
-	updateValues( name, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password, modInfo )
+	updateValues( name, description, playerCount, maxPlayers, map, playlist, ip, port, authPort, password, modInfo, region )
 	{
 		this.name = name
 		this.description = description
@@ -71,6 +73,7 @@ class GameServer
 		{
 			// Do nothing
 		}
+		this.region = region
 	}
 }
 


### PR DESCRIPTION
![mp_lobby0015](https://user-images.githubusercontent.com/40122905/183406146-435bd411-e1b4-4ec7-9392-e753cfebd591.jpg)

The idea behind this PR is to add information about geographic location of a gameserver the serverbrowser. This could be combined with a PR to the client that replaces the currently unused _latency_ column with a _region_ column.

Currently the accuracy of the region is limited to continent, e.g. _"Europe"_, _"North America"_, ...

It gets populated via response from 3rd-party GeoIP API service (https://ip-api.com).

I'm making this a draft for now cause there's a bunch of open questions:
- Do we want to use this 3rd-party `ip-api.com` (they offer 45 requests a minute for free) or another?
- Do we want to add an env variable that allows disabling GeoIP stuff?
- What do we want to show if GeoIP was unsuccessful? Empty string `""` or no field at all?
- Given the current accuracy of geographic location, is `region` the right name for the field?
