### PR TITLE
More descriptive errors for stryder response

### DIFF
--- a/client/clientauth.js
+++ b/client/clientauth.js
@@ -11,6 +11,7 @@ let shouldRequireSessionToken = process.env.REQUIRE_SESSION_TOKEN = true
 const { getRatelimit } = require( "../shared/ratelimit.js" )
 const {
 	STRYDER_RESPONSE,
+	STRYDER_PARSE,
 	UNAUTHORIZED_GAME,
 	UNAUTHORIZED_PWD,
 	PLAYER_NOT_FOUND,
@@ -61,7 +62,7 @@ module.exports = ( fastify, opts, done ) =>
 				}
 				catch
 				{
-					return { success: false, error: STRYDER_RESPONSE }
+					return { success: false, error: STRYDER_RESPONSE, response: authResponse.toString() }
 				}
 
 				let authJson
@@ -71,7 +72,7 @@ module.exports = ( fastify, opts, done ) =>
 				}
 				catch ( error )
 				{
-					return { success: false, error: STRYDER_RESPONSE }
+					return { success: false, error: STRYDER_PARSE, response: authResponse.toString() }
 				}
 
 				// check origin auth was fine

--- a/shared/errorcodes.js
+++ b/shared/errorcodes.js
@@ -21,6 +21,10 @@ const errorCodes = {
 	},
 	STRYDER_RESPONSE: {
 		enum: "STRYDER_RESPONSE",
+		msg: "Got bad response from stryder",
+	},
+	STRYDER_PARSE: {
+		enum: "STRYDER_PARSE",
 		msg: "Couldn't parse stryder response",
 	},
 	PLAYER_NOT_FOUND: {


### PR DESCRIPTION
I'm not sure if stryder can send anything potentially sensitive in the response that we dont want to expose to clients, but these errors don't get logged anyway (except when using https://github.com/R2Northstar/NorthstarLauncher/pull/180 ) so for debugging I don't think it's an issue?