### PR TITLE
Return status and header on HTTP error

### DIFF
--- a/shared/asynchttp.js
+++ b/shared/asynchttp.js
@@ -17,7 +17,10 @@ module.exports = {
 			let req = lib.request( params, reqResult =>
 			{
 				if ( reqResult.statusCode < 200 || reqResult.statusCode >= 300 )
-					return reject()
+					return reject( {
+						statusCode: reqResult.statusCode,
+						headers: reqResult.headers
+					} )
 
 				let data = []
 				reqResult.on( "data", c => data.push( c ) )


### PR DESCRIPTION
When performing an HTTP request, this returns the status code and headers of the response to help with figuring out why the request failed.

Mainly needed for #84 to check the response of the API in case of failure to check for ratelimit info etc.

Usage example

```javascript
try
{
    authServerResponse = await asyncHttp.request( {
        method: "GET",
        host: "example.com",
        port: 80,
        path: "/example"
    } )
}
catch (response_object)
{
    console.log(response_object)
}
```

Gives on error

```javascript
{
  statusCode: 200,
  headers: {
    date: 'Tue, 09 Aug 2022 21:39:23 GMT',
    'content-type': 'application/json; charset=utf-8',
    'content-length': '41',
    'access-control-allow-origin': '*',
    'example-rate-limit-remaining': '42'
  }
}
```

Currently existing functions do not try to reference this object so should not break existing calls to `asyncHttp.request()` in case of HTTP error.